### PR TITLE
#3 bootstrap3/button use default class only when :kind is not specified

### DIFF
--- a/src/main/untangled/ui/bootstrap3.cljc
+++ b/src/main/untangled/ui/bootstrap3.cljc
@@ -195,7 +195,7 @@
         button-classes   (cond-> "btn"
                            kind (str " btn-" (name kind))
                            size (str " btn-" (name size))
-                           (not size) (str " btn-default")
+                           (not kind) (str " btn-default")
                            as-block (str " btn-block")
                            incoming-classes (str " " incoming-classes))
         attrs            (-> attrs


### PR DESCRIPTION
`button` was adding `btn-default` class when `:size` was not not
specified. That's incorrect, `btn-default` specifies a style, not size,
thus should only be added when no explicit `:kind` given.
I have not updated ChangeLog since this is a quite minor fix.
Fixes #6.