### PR TITLE
Use return value of `UntangledNetwork start` as actual remote.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Moved easy untangled server to untangled.easy-server namespace. 
 - Moved all other server code to untangled.server namespace.
 - Added bootstrap3 namespace with helpers that can render passive and active bootstrap 3 elements.
+- If `net/UntangledNetwork start` returns something that implements `UntangledNetwork`, this value will be used as the actual remote by the app.
 
 0.8.2
 -----


### PR DESCRIPTION
Instead of calling `UntangledNetwork start` for side-effect only, app
will now use `start`s return value as the actual remote. This allows
remote to keep some initialized state, for example, the app object
that `start` receives as argument.
This is a BREAKING CHANGE: if a remote returns something other than,
potentially updated, `this`, things will break.

Resolves #1  

I am not quite sure about the breaking change thing. This behavior (require start to return a remote) makes sense from the "well-designed API" point of view, but on the other hand, it may break existing code. The other option is to check return value and `nil` or `(not (implements? UntangledNetwork))`, use the original value instead. That would not break things, but feels ugly. If you think it should use the second option, I'll happily rewrite it.

Also, I am not quite sure this change is correct. It seems so, it works for me, but my knowledge of CLJS/Om/Untangled is rather limited, so I may be very wrong here.